### PR TITLE
Stripped query parameters from the path

### DIFF
--- a/proxy-integration.js
+++ b/proxy-integration.js
@@ -17,7 +17,7 @@ class ProxyIntegration extends Integration {
         requestId: req.egContext.requestID
       });
 
-    let requestPath = req.url;
+    let requestPath =  req.params.length > 0 ? req.path :req.url ;
 
     if (settings.stripPath) {
       requestPath =


### PR DESCRIPTION
Sending query parameter in URL and in query parameter object does not work with C# lambdas